### PR TITLE
Mike's notes

### DIFF
--- a/src/data/angular2/simplicity.md
+++ b/src/data/angular2/simplicity.md
@@ -1,0 +1,5 @@
+Mike
+-------
+
+Of the frameworks I looked at, this is easily the most complex in terms of setup,
+integration with Kolibri, and API size. It's also nominally in beta still.

--- a/src/data/bbmn/simplicity.md
+++ b/src/data/bbmn/simplicity.md
@@ -1,0 +1,26 @@
+Mike
+-------
+
+More boilerplate than Riot, but as a result more explicit.
+For example, only a few properties are consistently bound to a Backbone.View on
+instantiation (and the rest must be explicitly bound in a constructor), whereas 
+with Riot what's bound to a tag depends also on *how* arguments are passed to 
+a tag.
+
+Marionette does cut away some boilerplate, and I think there's more to leverage in
+the library that we're just not familiar with, like [Behaviors](http://marionettejs.com/docs/v2.4.5/marionette.behaviors.html).
+
+Backbone+Marionette is more of a library than a framework, and the implication
+is that we'll have to do more work ourselves but I think it affords us the possibility
+of being noncommittal about some parts of the tech stack.
+
+For example, it would be possible (though not trivial) to gut BB+MN's rendering 
+system and replace it with a virtual DOM implementation. With other frameworks 
+it would probably be much harder to tinker with the rendering internals, which 
+could make our lives harder if we want to e.g. create a sandboxed view for 
+rendering 3rd party exercises a la Khan Academy's Perseus framework.
+
+That said, it's impossible for me to accurately evaluate the difficulty of integrating 
+Perseus exercises with any framework at this point -- it's all guesswork.
+ 
+ 

--- a/src/data/frameworks.json
+++ b/src/data/frameworks.json
@@ -7,7 +7,7 @@
       "composability":  2,
       "performance":    2,
       "documentation":  4,
-      "tooling":        3,
+      "tooling":        3.5,
       "size":           3,
       "community":      3.2,
       "flexibility":    3
@@ -35,7 +35,7 @@
       "composability":  5,
       "performance":    4,
       "documentation":  4,
-      "tooling":        3.5,
+      "tooling":        3,
       "size":           2,
       "community":      4,
       "flexibility":    2

--- a/src/data/frameworks.json
+++ b/src/data/frameworks.json
@@ -4,7 +4,7 @@
     "display": "BB+Mn",
     "scores": {
       "simplicity":     2,
-      "composability":  2,
+      "composability":  3,
       "performance":    2,
       "documentation":  4,
       "tooling":        3.5,

--- a/src/data/riot/simplicity.md
+++ b/src/data/riot/simplicity.md
@@ -1,0 +1,10 @@
+Mike
+-------
+
+It's nice that behavior, html, and styles are presented in one self-contained unit.
+Of the frameworks I reviewed it's the simplest to use and also reason about.
+One potential cost is that if we want to do something "against" the framework
+it will not be so easy.
+
+Riot is firmly a framework, while Backbone+Marionette in contrast is closer the 
+library end of the spectrum.


### PR DESCRIPTION
From the commit msgs:

## 	Switch order of tooling for BB+MN and Ang

```txt
Based on my experience getting Angular2 running & integrated
with Kolibri, I would switch the relative order of these two.

BB+MN in contrast is pretty straightforward to get running,
nor do I find the tooling to be inadequate -- i.e. we don't
get sourcemaps out of the box, but in contrast there's
*much* less source and the sourcemaps should be pretty
straightforward to implement.
```

## Amend composability

```txt
IMO all of the frameworks are much closer by this metric.
I think for BB+MN it's probably true that it's *easier* to
do something wrong/messy since it's overall the least
opinionated, but that doesn't prevent it from being adequate
to make a highly composable application.

Another factor that's harder to quantify is institutional
knowledge -- as a team we've got a lot of hard-earned
know-how for building BB apps, and MN complements that style
very nicely.
```

## Random thoughts

I'd ideally like to take a closer look at Vue.js.
Based on your own evaluation it's close to the top on a lot of the metrics, whereas the others are a little more spread across the board.
It appeals to me personally because it feels more "Backboney" than the other frameworks we've looked at, and so my sense is that our institutional knowledge will transfer to it more readily.
But because I wasn't able to look at it extensively myself, I'm gambling a bit in this assessment.